### PR TITLE
Improve hero responsiveness at mid breakpoints

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -659,6 +659,12 @@ html[lang="id"] [data-lang="en"] {
 .element-3 { bottom: 20%; left: 20%; animation-delay: 4s; }
 @keyframes float { 0%,100%{ transform: translateY(0) rotate(0deg);} 50%{ transform: translateY(-20px) rotate(180deg);} }
 
+@media (max-width: 1200px) {
+  .hero-section { padding: clamp(72px, 10vh, 140px) 0 var(--space-2xl); }
+  .hero-content { grid-template-columns: 1.4fr 1fr; gap: clamp(var(--space-xl), 5vw, var(--space-2xl)); }
+  .hero-actions { flex-wrap: wrap; gap: var(--space-md); row-gap: var(--space-sm); }
+}
+
 /* Responsive: hero */
 @media (max-width: 768px) {
   .hero-content { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- add a 1200px breakpoint to rebalance the hero grid columns for mid-sized viewports
- increase responsive padding and gaps so hero calls-to-action have breathing room when space tightens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920289913f883279a9114c15925db45)