### PR TITLE
Refine hero typography sizing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -566,12 +566,39 @@ html[lang="id"] [data-lang="en"] {
 }
 .hero-greeting { margin-bottom: var(--space-sm); }
 .greeting-text { font-size: 18px; color: var(--text-muted); font-weight: 500; }
-.hero-title { margin-bottom: var(--space-lg); line-height: 1.1; }
-.title-name { display: block; font-size: 64px; font-weight: 900; color: var(--text-primary); margin-bottom: var(--space-sm); }
-.title-role { display: block; font-size: 48px; font-weight: 700; color: var(--text-secondary); margin-bottom: var(--space-xs); }
-.title-specialization { display: block; font-size: 32px; font-weight: 600; color: var(--text-muted); }
+.hero-title { margin-bottom: clamp(var(--space-md), 2vw, var(--space-lg)); line-height: 1.08; }
+.title-name {
+  display: block;
+  font-size: clamp(44px, 3.6vw + 14px, 68px);
+  font-weight: 900;
+  color: var(--text-primary);
+  margin-bottom: clamp(var(--space-xs), 1vw, var(--space-sm));
+  line-height: 1.05;
+}
+.title-role {
+  display: block;
+  font-size: clamp(32px, 2.8vw + 12px, 56px);
+  font-weight: 700;
+  color: var(--text-secondary);
+  margin-bottom: clamp(6px, 0.8vw, var(--space-xs));
+  line-height: 1.08;
+}
+.title-specialization {
+  display: block;
+  font-size: clamp(24px, 2.2vw + 6px, 40px);
+  font-weight: 600;
+  color: var(--text-muted);
+  line-height: 1.15;
+}
 .accent-text { color: var(--accent-primary); font-weight: 700; }
-.hero-description { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; font-size: 20px; color: var(--text-secondary); margin-bottom: var(--space-xl); max-width: 600px; line-height: 1.6; }
+.hero-description {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: clamp(17px, 0.9vw + 9px, 21px);
+  color: var(--text-secondary);
+  margin-bottom: clamp(var(--space-lg), 2vw, var(--space-xl));
+  max-width: 600px;
+  line-height: 1.6;
+}
 .font-inter-loaded .hero-description {
   font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }


### PR DESCRIPTION
## Summary
- update hero heading and description typography to use clamp-based sizing for smoother scaling across viewport widths
- adjust line-heights and margins to preserve rhythm while preventing hero text from crowding the image at mid-sized viewports

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69202986f9b88327996092844c656a33)