### PR TITLE
Improve hero layout responsiveness

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -560,8 +560,8 @@ html[lang="id"] [data-lang="en"] {
 }
 .hero-content {
   display: grid;
-  grid-template-columns: 2fr 1fr;
-  gap: var(--space-2xl);
+  grid-template-columns: minmax(0, 1.4fr) minmax(320px, 1fr);
+  gap: clamp(var(--space-xl), 5vw, var(--space-2xl));
   align-items: center;
 }
 .hero-greeting { margin-bottom: var(--space-sm); }
@@ -575,11 +575,31 @@ html[lang="id"] [data-lang="en"] {
 .font-inter-loaded .hero-description {
   font-family: var(--font-inter), system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
-.hero-stats { display: flex; gap: var(--space-xl); margin-bottom: var(--space-xl); }
-.stat-item { text-align: center; }
+.hero-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-xl);
+  row-gap: var(--space-md);
+  margin-bottom: var(--space-xl);
+}
+.stat-item {
+  text-align: center;
+  flex: 1 1 160px;
+  min-width: 140px;
+}
 .stat-number { display: block; font-size: 36px; font-weight: 900; color: var(--accent-primary); margin-bottom: var(--space-xs); }
 .stat-label { font-size: 14px; color: var(--text-muted); font-weight: 500; }
-.hero-actions { display: flex; gap: var(--space-md); }
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md);
+  row-gap: var(--space-sm);
+}
+.hero-actions > * {
+  flex: 1 1 240px;
+  min-width: 220px;
+  justify-content: center;
+}
 
 /* Buttons in hero */
 .hero-cta {


### PR DESCRIPTION
## Summary
- adjust hero grid columns and gap to shrink more fluidly at intermediate widths
- allow hero stats and CTA buttons to wrap with sensible minimum widths to prevent overflow at high zoom levels

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69203805a03c8327bb76c664cc81f015)